### PR TITLE
fix: outline around dropzone

### DIFF
--- a/client/src/components/AvatarFileUploader/AvatarFileUploader.style.tsx
+++ b/client/src/components/AvatarFileUploader/AvatarFileUploader.style.tsx
@@ -22,6 +22,7 @@ const AvatarContainer = styled.section<{ size?: string }>`
     transform: scale(0.85);
     transition: 0.2s;
     cursor: pointer;
+    outline: none;
 
     p {
       margin: auto;


### PR DESCRIPTION
Hey,

this is just a first pull request with a small issue that I found.

When clicking on the "Change Avatar", the component is focused and gets an outline on some browsers. `outline: none` fixes that.
![image](https://user-images.githubusercontent.com/15076254/87664622-db1da980-c765-11ea-8017-5f2596eb3d41.png)


If you are looking for contributors, I'd like to commit more than just simple style changes 😄 

Cheers